### PR TITLE
Update passport-oauth2 dependency to address security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,102 @@
 {
   "name": "passport-microsoft",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.1.0",
+      "dependencies": {
+        "passport-oauth2": "^1.6.1",
+        "pkginfo": "0.2.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
+      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    }
+  },
   "dependencies": {
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
     },
     "passport-oauth2": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.2.0.tgz",
-      "integrity": "sha1-SWE6PsqFx6HmW/EBnitrgKEMisI=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
+      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
       "requires": {
+        "base64url": "3.x.x",
         "oauth": "0.9.x",
         "passport-strategy": "1.x.x",
-        "uid2": "0.0.x"
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
@@ -33,6 +113,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-microsoft",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Microsoft [Graph] authentication strategy for Passport.",
   "keywords": [
     "passport",
@@ -32,8 +32,8 @@
   ],
   "main": "./lib/",
   "dependencies": {
-    "pkginfo": "0.2.x",
-    "passport-oauth2": "1.2.0"
+    "passport-oauth2": "1.6.1",
+    "pkginfo": "0.2.x"
   },
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
Hello!
`passport-oauth2` has a security vulnerability in the version used here, so I updated it to the latest version (1.6.1), which addresses the issue. See https://github.com/advisories/GHSA-f794-r6xc-hf3v