### PR TITLE
add graphApiVersion option

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -50,6 +50,7 @@ function MicrosoftStrategy(options, verify) {
   options.tokenURL = options.tokenURL || `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
   options.scopeSeparator = options.scopeSeparator || ' ';
   options.customHeaders = options.customHeaders || {};
+  options.graphApiVersion = options.graphApiVersion || "v1.0"
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'microsoft';
@@ -91,7 +92,7 @@ MicrosoftStrategy.prototype.userProfile = function (accessToken, done) {
 
   this._oauth2.useAuthorizationHeaderforGET(true);
   this._oauth2.get(
-    'https://graph.microsoft.com/v1.0/me/',
+    `https://graph.microsoft.com/${options.graphApiVersion}/me/`,
     accessToken,
     // eslint-disable-next-line no-unused-vars
     function (err, body, res) {


### PR DESCRIPTION
The Microsoft Graph api now has two available versions:
- `v1.0`
- `beta`
It would be nice to be able to switch between them. 