### PR TITLE
BREAKING: Treating the User Principal Name as an email address is now opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ Microsoft's developer site.
         tokenURL: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 
         // [Optional] The Microsoft Graph API version (e.g., 'v1.0', 'beta'). Defaults to 'v1.0'.
-        graphApiVersion: 'v1.0'
+        graphApiVersion: 'v1.0',
+
+        // [Optional] If true, will push the User Principal Name into the `emails` array in the Passport.js profile. Defaults to false.
+        addUPNAsEmail: false,
       },
       function(accessToken, refreshToken, profile, done) {
         User.findOrCreate({ userId: profile.id }, function (err, user) {

--- a/example/login/app.js
+++ b/example/login/app.js
@@ -39,6 +39,9 @@ passport.use(new MicrosoftStrategy({
   
   // Optional, uses 'common' as the default
   tenant: MICROSOFT_GRAPH_TENANT_ID,
+
+  // Optional, whether or not to include the User Principal Name into the emails field in the user profile
+  addUPNAsEmail: false,
 },
 function (accessToken, refreshToken, profile, done) {
   // asynchronous verification, for effect...

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -54,6 +54,7 @@ function MicrosoftStrategy(options, verify) {
   OAuth2Strategy.call(this, options, verify);
   this.name = 'microsoft';
   this._graphApiVersion = options.graphApiVersion || 'v1.0';
+  this._addUPNAsEmail = ('addUPNAsEmail' in options) ? options.addUPNAsEmail : false;
 }
 
 /**
@@ -89,10 +90,10 @@ MicrosoftStrategy.prototype.authorizationParams = function(options) {
 };
 
 MicrosoftStrategy.prototype.userProfile = function (accessToken, done) {
-
-  this._oauth2.useAuthorizationHeaderforGET(true);
-  this._oauth2.get(
-    `https://graph.microsoft.com/${this._graphApiVersion}/me/`,
+  var strategy = this;
+  strategy._oauth2.useAuthorizationHeaderforGET(true);
+  strategy._oauth2.get(
+    `https://graph.microsoft.com/${strategy._graphApiVersion}/me/`,
     accessToken,
     // eslint-disable-next-line no-unused-vars
     function (err, body, res) {
@@ -111,7 +112,15 @@ MicrosoftStrategy.prototype.userProfile = function (accessToken, done) {
         profile.displayName = json.displayName;
         profile.name.familyName = json.surname;
         profile.name.givenName = json.givenName;
-        profile.emails = [{ type: 'work', value: json.mail || json.userPrincipalName }];
+        profile.emails = [];
+        var isNotEmpty = str => str && typeof str === 'string' && str.trim().length;
+        if (isNotEmpty(json.mail)) {
+          profile.emails.push({ type: 'work', value: json.mail });
+        }
+
+        if (strategy._addUPNAsEmail && isNotEmpty(json.userPrincipalName)) {
+          profile.emails.push({ type: 'work', value: json.userPrincipalName});
+        }
 
         profile._raw = body;
         profile._json = json;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -112,6 +112,7 @@ MicrosoftStrategy.prototype.userProfile = function (accessToken, done) {
         profile.displayName = json.displayName;
         profile.name.familyName = json.surname;
         profile.name.givenName = json.givenName;
+        profile.userPrincipalName = json.userPrincipalName;
         profile.emails = [];
         var isNotEmpty = str => str && typeof str === 'string' && str.trim().length;
         if (isNotEmpty(json.mail)) {


### PR DESCRIPTION
Previously, if the Graph API did not return a value in the `mail` field, the User Principal Name (UPN) would be substituted automatically. This was beneficial for those who follow the recommended convention of having the UPN be the same as the email address.

However, the UPN does not always reflect the user's email address and can be changed by an administrator.

To avoid consuming applications blindly relying on an assumption that UPN and email is always the same, this behavior is now opt-in. If a valid email is found in the `mail` field, it will be added to the `emails` array in the Passport.js profile. If the new option, `addUPNAsEmail`, is set to `true` in the configuration, the UPN will be added into the `emails` array as well. This means there could be a scenario where zero, one, or two email address are found in the profile's `emails` field.

For those who wish to maintain the semantic separation of email and UPN, the UPN is also available now as a separate property on the profile, `userPrincipalName`.

On a related note, it is not recommended for applications to use one of the emails or the UPN as a user identifier, as these values can be changed and are not guaranteed to represent a stable identity. Instead, use the `id` field.